### PR TITLE
Show correct description for Media Session Master

### DIFF
--- a/util/content.ts
+++ b/util/content.ts
@@ -314,7 +314,7 @@ export const projects: SectionContent = [
   {
     icons: [icons.js, icons.chrome],
     name: 'Media Session Master',
-    description: 'A Discord bot that uses image processing to make pictures from templates.',
+    description: 'Utilize Chrome\'s MediaSession API within multiple sites.',
     buttons: [
       {
         name: 'GitHub',


### PR DESCRIPTION
Changes the description for [Media Session Master](https://github.com/Snazzah/MediaSessionMaster) to use it's repository description, rather than [Photobox](https://photobox.pw/)'s one a few lines up.
